### PR TITLE
feat: do not update uninitialized torrents #28

### DIFF
--- a/torrents_updater.py
+++ b/torrents_updater.py
@@ -1,10 +1,16 @@
 # telnetdoogie -  https://github.com/telnetdoogie/transmission-trackers
+import json
 import os
 import time
 
 from transmission_rpc import Torrent, Client
 
 from trackers_updater import TrackerUpdater
+
+
+def torrent_info(torrent: Torrent):
+    json_output = json.dumps(torrent.__dict__, indent=4)
+    return json_output
 
 
 class TorrentUpdater:
@@ -20,10 +26,10 @@ class TorrentUpdater:
         self.trackers_list = "https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best.txt"
         self.period: int = 120
         self.tracker_expiration_time: int = 28800  # 8 hours
-
+        self.is_debug = False
         self.override_params_from_env()
 
-        self.updater = TrackerUpdater(url=self.trackers_list, expiration_time=self.tracker_expiration_time)
+        self.updater = TrackerUpdater(url=self.trackers_list, expiration_time=self.tracker_expiration_time, debug=self.is_debug)
         self.updater.start()
 
     def override_params_from_env(self):
@@ -36,6 +42,7 @@ class TorrentUpdater:
             "TRANSMISSION_PASS": ("password", str),
             "TORRENT_CHECK_PERIOD": ("period", int),
             "TRACKER_EXPIRATION": ("tracker_expiration_time", int),
+            "DEBUG": ("is_debug", bool),
         }
         # Seconds-based environment variables
         seconds_variables = {"TORRENT_CHECK_PERIOD", "TRACKER_EXPIRATION"}
@@ -58,6 +65,7 @@ class TorrentUpdater:
                     exit(1)
 
     def update_trackers(self, torrent: Torrent):
+
         try:
             tc = Client(username=self.user, password=self.password, host=self.host, port=self.port)
             current_trackers = tc.get_torrent(torrent_id=torrent.hashString).tracker_list
@@ -68,10 +76,12 @@ class TorrentUpdater:
                 print(f'Updating trackers for "{torrent.name}"')
                 print(f" - {len(current_trackers)} current trackers")
                 print(f" - {len(all_trackers)} trackers after update")
-                tc.change_torrent(ids=torrent.hashString, tracker_list=[all_trackers])
+                tc.change_torrent(ids=torrent.hashString, tracker_list=[[t] for t in all_trackers])
                 print(f' - Trackers updated for "{torrent.name}"')
         except Exception as e:
             print(f"An error occurred updating trackers: {e}")
+            if self.is_debug:
+                print(torrent_info(torrent))
         return
 
     def get_torrents(self):
@@ -93,6 +103,21 @@ class TorrentUpdater:
 
         print("Trackers loaded.")
         self.check_and_update_torrents()
+
+    def can_update_torrent(self, torrent: Torrent):
+        # Do not update private torrents
+        if torrent.is_private:
+            if self.is_debug:
+                print(f"  - WILL NOT update private torrent: {torrent.name}")
+            return False
+        # Do not (Can not) update torrents that have not been started
+        if torrent.is_stalled is True and torrent.activity_date < torrent.added_date:
+            if self.is_debug:
+                print(f"  - WILL NOT update unstarted torrent: {torrent.name}")
+            return False
+        if self.is_debug:
+            print(f"  - WILL attempt to update torrent: {torrent.name}")
+        return True
 
     def check_and_update_torrents(self):
         print(f"Watching for new torrents every {self.period} seconds...")
@@ -118,9 +143,7 @@ class TorrentUpdater:
 
             for torrent in torrents:
                 # don't change anything in private torrents
-                if not torrent.is_private:
+                if self.can_update_torrent(torrent):
                     self.update_trackers(torrent)
+
             time.sleep(self.period)
-
-
-

--- a/trackers_updater.py
+++ b/trackers_updater.py
@@ -6,7 +6,7 @@ import requests
 
 
 class TrackerUpdater:
-    def __init__(self, url, expiration_time: int):
+    def __init__(self, url, expiration_time: int, debug: bool = False):
         print("TrackerUpdater Initializing...")
         self.url = url
         self.list_expiration_time = expiration_time
@@ -15,6 +15,7 @@ class TrackerUpdater:
         self.trackers_timestamp = None
         self.lock = threading.Lock()
         self.initial_load_event = threading.Event()
+        self.is_debug = debug
 
     def start(self):
         thread = threading.Thread(target=self.__run, daemon=True)
@@ -32,10 +33,12 @@ class TrackerUpdater:
             time.sleep(60 * 5)
 
     def __print_trackers(self):
-        current_time = time.time()
-        print(f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(current_time))}: Trackers loaded from {self.url}")
-        for index, tracker in enumerate(self.trackers):
-            print(f"  {index:02} : {tracker}")
+        if self.is_debug:
+            current_time = time.time()
+            print(f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(current_time))}: Trackers loaded from {self.url}")
+            for index, tracker in enumerate(self.trackers):
+                print(f"  {index:02} : {tracker}")
+        pass
 
     def __load_trackers(self):
         with self.lock:


### PR DESCRIPTION
This change will **NOT** attempt to update uninitialized / unstarted **AND** stalled torrents to avoid errors in the transmission API.
Torrents that HAVE started but are stalled will still be updated.

It also adds a DEBUG option to environment variables to reduce output in normal running